### PR TITLE
added redis support

### DIFF
--- a/vars.go
+++ b/vars.go
@@ -24,6 +24,7 @@ const (
 	mysqlImage         = "mysql"
 	postgresImage      = "postgres"
 	elasticsearchImage = "elasticsearch"
+	redisImage         = "redis"
 
 	// MySQLUsername must be passed as username when connecting to mysql
 	MySQLUsername = "root"


### PR DESCRIPTION
Had a need for Redis support, so I thought I'd make the addition quick. It uses the official redis image from Docker: https://hub.docker.com/_/redis/