### PR TITLE
Add support for running custom containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ You can start PostgreSQL and MySQL in a similar fashion.
 
 It is also possible to start a custom container (in this example, a RabbitMQ container):
 
-```
+```go
 	c, ip, port, err := SetupCustomContainer("rabbitmq", 5672, 10*time.Second)
 	if err != nil {
 		log.Fatalf("Could not setup container: %s", err

--- a/README.md
+++ b/README.md
@@ -106,7 +106,28 @@ func main() {
 }
 ```
 
-You can start PostgreSQL and MySQL in a similar fashion with
+You can start PostgreSQL and MySQL in a similar fashion.
+
+It is also possible to start a custom container (in this example, a RabbitMQ container):
+
+```
+	c, ip, port, err := SetupCustomContainer("rabbitmq", 5672, 10*time.Second)
+	if err != nil {
+		log.Fatalf("Could not setup container: %s", err
+	}
+	defer c.KillRemove()
+
+	err = ConnectToCustomContainer(fmt.Sprintf("%v:%v", ip, port), 15, time.Millisecond*500, func(url string) bool {
+		amqp, err := amqp.Dial(fmt.Sprintf("amqp://%v", url))
+		if err != nil {
+			return false
+		}
+		defer amqp.Close()
+		return true
+	})
+
+	...
+```
 
 ## Write awesome tests
 

--- a/custom.go
+++ b/custom.go
@@ -1,0 +1,39 @@
+package dockertest
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"time"
+)
+
+// SetupCustomContainer sets up a real an instance of the given image for testing purposes,
+// using a Docker container. It returns the container ID and its IP address,
+// or makes the test fail on error.
+func SetupCustomContainer(imageName string, exposedPort int, timeOut time.Duration, extraDockerArgs ...string) (c ContainerID, ip string, localPort int, err error) {
+	localPort = RandomPort()
+	forward := fmt.Sprintf("%d:%d", localPort, exposedPort)
+	if BindDockerToLocalhost != "" {
+		forward = "127.0.0.1:" + forward
+	}
+	c, ip, err = SetupContainer(RethinkDBImageName, localPort, timeOut, func() (string, error) {
+		args := make([]string, 0, len(extraDockerArgs)+7)
+		args = append(args, "--name", GenerateContainerID(), "-d", "-P", "-p", forward)
+		args = append(args, extraDockerArgs...)
+		args = append(args, imageName)
+		return run(args...)
+	})
+	return
+}
+
+// ConnectToCustomContainer attempts to connect to a custom container until successful or the maximum number of tries is reached.
+func ConnectToCustomContainer(url string, tries int, delay time.Duration, connector func(url string) bool) error {
+	for try := 0; try <= tries; try++ {
+		time.Sleep(delay)
+		if connector(url) {
+			return nil
+		}
+		log.Printf("Try %d failed. Retrying.", try)
+	}
+	return errors.New("Could not set up custom container.")
+}

--- a/docker_test.go
+++ b/docker_test.go
@@ -11,8 +11,8 @@ import (
 	"gopkg.in/mgo.v2"
 
 	"github.com/garyburd/redigo/redis"
-	"github.com/mattbaird/elastigo/lib"
 	. "github.com/ory-am/dockertest"
+	"github.com/mattbaird/elastigo/lib"
 	"github.com/streadway/amqp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -150,4 +150,20 @@ func TestConnectToNSQd(t *testing.T) {
 	})
 	assert.Nil(t, err)
 	defer c.KillRemove()
+}
+
+func TestCustomContainer(t *testing.T) {
+	c1, ip, port, err := SetupCustomContainer("rabbitmq", 5672, 10*time.Second)
+	assert.Nil(t, err)
+	defer c1.KillRemove()
+
+	err = ConnectToCustomContainer(fmt.Sprintf("%v:%v", ip, port), 15, time.Millisecond*500, func(url string) bool {
+		amqp, err := amqp.Dial(fmt.Sprintf("amqp://%v", url))
+		if err != nil {
+			return false
+		}
+		defer amqp.Close()
+		return true
+	})
+	assert.Nil(t, err)
 }


### PR DESCRIPTION
The rationale is that sometimes my integration tests need to spin up a container with the code being tested (e.g. an API server). It is nice to be able to do it in a similar way of the predefined containers.