### PR TITLE
Adding support for loading sql file using docker-entrypoint-initdb.d by default {different branch }

### DIFF
--- a/docker_integration_test.go
+++ b/docker_integration_test.go
@@ -114,6 +114,21 @@ func TestConnectToMySQLWithCustomizedDB(t *testing.T) {
 	defer c.KillRemove()
 }
 
+func TestConnectToMySQLWithSqlFile(t *testing.T) {
+
+	MySQLDatabse = "world"
+	c, err := ConnectToMySQL(20, time.Second, func(url string) bool {
+		db, err := sql.Open("mysql", url)
+		if err != nil {
+			return false
+		}
+		defer db.Close()
+		return true
+	})
+	assert.Nil(t, err)
+	defer c.KillRemove()
+}
+
 func TestConnectToMongoDB(t *testing.T) {
 	c, err := ConnectToMongoDB(15, time.Millisecond*500, func(url string) bool {
 		db, err := mgo.Dial(url)

--- a/mysql.go
+++ b/mysql.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
+	"strings"
 	"time"
 
 	mysql "github.com/go-sql-driver/mysql"
@@ -23,9 +25,18 @@ func SetupMySQLContainer() (c ContainerID, ip string, port int, err error) {
 	if BindDockerToLocalhost != "" {
 		forward = "127.0.0.1:" + forward
 	}
+
+	// geting the curnnet dir.
+	dir, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+	currnetDir := strings.Replace(dir, " ", "\\ ", -1)
+
 	c, ip, err = SetupContainer(MySQLImageName, port, 10*time.Second, func() (string, error) {
-		return run("--name", GenerateContainerID(), "-d", "-p", forward, "-e", fmt.Sprintf("MYSQL_ROOT_PASSWORD=%s", MySQLPassword), MySQLImageName)
+		return run("--name", GenerateContainerID(), "-d", "-p", forward, "-e", fmt.Sprintf("MYSQL_ROOT_PASSWORD=%s", MySQLPassword), "-v", fmt.Sprintf("%s:/docker-entrypoint-initdb.d", currnetDir), MySQLImageName)
 	})
+
 	return
 }
 
@@ -39,7 +50,7 @@ func ConnectToMySQL(tries int, delay time.Duration, connector func(url string) b
 
 	for try := 0; try <= tries; try++ {
 		time.Sleep(delay)
-		url := fmt.Sprintf("%s:%s@tcp(%s:%d)/mysql", MySQLUsername, MySQLPassword, ip, port)
+		url := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s", MySQLUsername, MySQLPassword, ip, port, MySQLDatabse)
 		if connector(url) {
 			return c, nil
 		}

--- a/vars.go
+++ b/vars.go
@@ -61,6 +61,9 @@ var (
 	// MySQLPassword must be passed as password when connecting to mysql
 	MySQLPassword = "root"
 
+	// MySQLDatabse must be passed as database when connecting to mysql
+	MySQLDatabse = "mysql"
+
 	// PostgresUsername must be passed as username when connecting to postgres
 	PostgresUsername = "postgres"
 


### PR DESCRIPTION
I created this PR because i think it will be easier to test up to date data and this can replace the customize DB method.

You just need to put you SQL file in the same directory of your test file and it will be added to the container docker-entrypoint-initdb.d folder and will be installed.

I did it for MySQL now but it can be done for PostgreSQL as well.

Test Are working fine on ubuntu , didn't test it on win/mac .

what do you think ?

thanks,
Miki