### PR TITLE
Restructure port-mapping endpoints. API-BREAKING!

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ from [camlistore](https://github.com/camlistore/camlistore).
 
 This fork detects automatically, if [Docker Toolbox](https://www.docker.com/toolbox)
 is installed. If it is, Docker integration on Windows and Mac OSX can be used without any additional work.
-To avoid port collisions when using docker-machine, Dockertest chooses a random port to bind the requested image.
+Port collisions when using docker-machine are avoided by letting Docker choose public ports.
 
 Dockertest ships with support for these backends:
 * PostgreSQL

--- a/container_test.go
+++ b/container_test.go
@@ -1,0 +1,24 @@
+package dockertest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFailingContainer(t *testing.T) {
+	assert := assert.New(t)
+
+	c := ContainerID("nope")
+	assert.Error(c.Kill())
+	assert.Error(c.KillRemove())
+	assert.Error(c.Remove())
+	{
+		_, err := c.OrderedPorts([]int{})
+		assert.Error(err)
+	}
+	{
+		_, err := c.lookup([]int{}, 5)
+		assert.Error(err)
+	}
+}

--- a/custom.go
+++ b/custom.go
@@ -2,26 +2,20 @@ package dockertest
 
 import (
 	"errors"
-	"fmt"
 	"log"
 	"time"
 )
 
 // SetupCustomContainer sets up a real an instance of the given image for testing purposes,
-// using a Docker container. It returns the container ID and its IP address,
+// using a Docker container. It returns the container ID and its Service,
 // or makes the test fail on error.
-func SetupCustomContainer(imageName string, exposedPort int, timeOut time.Duration, extraDockerArgs ...string) (c ContainerID, ip string, localPort int, err error) {
-	localPort = RandomPort()
-	forward := fmt.Sprintf("%d:%d", localPort, exposedPort)
-	if BindDockerToLocalhost != "" {
-		forward = "127.0.0.1:" + forward
-	}
-	c, ip, err = SetupContainer(imageName, localPort, timeOut, func() (string, error) {
+func SetupCustomContainer(imageName string, exposedPort int, timeOut time.Duration, extraDockerArgs ...string) (c ContainerID, svc ServicePort, err error) {
+	c, svc, err = SetupContainer(imageName, exposedPort, timeOut, func() (string, error) {
 		args := make([]string, 0, len(extraDockerArgs)+7)
-		args = append(args, "--name", GenerateContainerID(), "-d", "-P", "-p", forward)
+		args = append(args, "--name", GenerateContainerID(), "-d", "-P")
 		args = append(args, extraDockerArgs...)
 		args = append(args, imageName)
-		return run(args...)
+		return runService([]int{exposedPort}, args...)
 	})
 	return
 }

--- a/docker_integration_test.go
+++ b/docker_integration_test.go
@@ -167,8 +167,8 @@ func TestConnectToRedis(t *testing.T) {
 }
 
 func TestConnectToNSQLookupd(t *testing.T) {
-	c, err := ConnectToNSQLookupd(15, time.Millisecond*500, func(ip string, httpPort int, tcpPort int) bool {
-		resp, err := http.Get(fmt.Sprintf("http://%s:%d/ping", ip, httpPort))
+	c, err := ConnectToNSQLookupd(15, time.Millisecond*500, func(httpPort ServicePort, tcpPort ServicePort) bool {
+		resp, err := http.Get(fmt.Sprintf("http://%s/ping", httpPort))
 		require.Nil(t, err)
 		require.Equal(t, resp.StatusCode, 200)
 
@@ -179,8 +179,8 @@ func TestConnectToNSQLookupd(t *testing.T) {
 }
 
 func TestConnectToNSQd(t *testing.T) {
-	c, err := ConnectToNSQd(15, time.Millisecond*500, func(ip string, httpPort int, tcpPort int) bool {
-		resp, err := http.Get(fmt.Sprintf("http://%s:%d/ping", ip, httpPort))
+	c, err := ConnectToNSQd(15, time.Millisecond*500, func(httpPort ServicePort, tcpPort ServicePort) bool {
+		resp, err := http.Get(fmt.Sprintf("http://%s/ping", httpPort))
 		require.Nil(t, err)
 		require.Equal(t, resp.StatusCode, 200)
 		return true
@@ -190,11 +190,11 @@ func TestConnectToNSQd(t *testing.T) {
 }
 
 func TestCustomContainer(t *testing.T) {
-	c1, ip, port, err := SetupCustomContainer("rabbitmq", 5672, 10*time.Second)
+	c1, svc, err := SetupCustomContainer("rabbitmq", 5672, 10*time.Second)
 	assert.Nil(t, err)
 	defer c1.KillRemove()
 
-	err = ConnectToCustomContainer(fmt.Sprintf("%v:%v", ip, port), 15, time.Millisecond*500, func(url string) bool {
+	err = ConnectToCustomContainer(svc.String(), 15, time.Millisecond*500, func(url string) bool {
 		amqp, err := amqp.Dial(fmt.Sprintf("amqp://%v", url))
 		if err != nil {
 			return false

--- a/mongodb.go
+++ b/mongodb.go
@@ -8,16 +8,15 @@ import (
 )
 
 // SetupMongoContainer sets up a real MongoDB instance for testing purposes,
-// using a Docker container. It returns the container ID and its IP address,
+// using a Docker container. It returns the container ID and its Service,
 // or makes the test fail on error.
-func SetupMongoContainer() (c ContainerID, ip string, port int, err error) {
-	port = RandomPort()
-	forward := fmt.Sprintf("%d:%d", port, 27017)
+func SetupMongoContainer() (c ContainerID, svc ServicePort, err error) {
+	forward := fmt.Sprintf(":%d", 27017)
 	if BindDockerToLocalhost != "" {
 		forward = "127.0.0.1:" + forward
 	}
-	c, ip, err = SetupContainer(MongoDBImageName, port, 10*time.Second, func() (string, error) {
-		res, err := run("--name", GenerateContainerID(), "-d", "-P", "-p", forward, MongoDBImageName)
+	c, svc, err = SetupContainer(MongoDBImageName, 27017, 10*time.Second, func() (string, error) {
+		res, err := runService([]int{27017}, "--name", GenerateContainerID(), "-d", "-P", MongoDBImageName)
 		return res, err
 	})
 	return
@@ -26,15 +25,14 @@ func SetupMongoContainer() (c ContainerID, ip string, port int, err error) {
 // ConnectToMongoDB starts a MongoDB image and passes the database url to the connector callback.
 // The url will match the ip:port pattern (e.g. 123.123.123.123:4241)
 func ConnectToMongoDB(tries int, delay time.Duration, connector func(url string) bool) (c ContainerID, err error) {
-	c, ip, port, err := SetupMongoContainer()
+	c, svc, err := SetupMongoContainer()
 	if err != nil {
 		return c, fmt.Errorf("Could not set up MongoDB container: %v", err)
 	}
 
 	for try := 0; try <= tries; try++ {
 		time.Sleep(delay)
-		url := fmt.Sprintf("%s:%d", ip, port)
-		if connector(url) {
+		if connector(svc.String()) {
 			return c, nil
 		}
 		log.Printf("Try %d failed. Retrying.", try)

--- a/mysql.go
+++ b/mysql.go
@@ -15,16 +15,11 @@ const (
 )
 
 // SetupMySQLContainer sets up a real MySQL instance for testing purposes,
-// using a Docker container. It returns the container ID and its IP address,
+// using a Docker container. It returns the container ID and its Service,
 // or makes the test fail on error.
-func SetupMySQLContainer() (c ContainerID, ip string, port int, err error) {
-	port = RandomPort()
-	forward := fmt.Sprintf("%d:%d", port, 3306)
-	if BindDockerToLocalhost != "" {
-		forward = "127.0.0.1:" + forward
-	}
-	c, ip, err = SetupContainer(MySQLImageName, port, 10*time.Second, func() (string, error) {
-		return run("--name", GenerateContainerID(), "-d", "-p", forward, "-e", fmt.Sprintf("MYSQL_ROOT_PASSWORD=%s", MySQLPassword), MySQLImageName)
+func SetupMySQLContainer() (c ContainerID, svc ServicePort, err error) {
+	c, svc, err = SetupContainer(MySQLImageName, 3306, 10*time.Second, func() (string, error) {
+		return runService([]int{3306}, "--name", GenerateContainerID(), "-d", "-e", fmt.Sprintf("MYSQL_ROOT_PASSWORD=%s", MySQLPassword), MySQLImageName)
 	})
 	return
 }
@@ -32,14 +27,14 @@ func SetupMySQLContainer() (c ContainerID, ip string, port int, err error) {
 // ConnectToMySQL starts a MySQL image and passes the database url to the connector callback function.
 // The url will match the username:password@tcp(ip:port) pattern (e.g. `root:root@tcp(123.123.123.123:3131)`)
 func ConnectToMySQL(tries int, delay time.Duration, connector func(url string) bool) (c ContainerID, err error) {
-	c, ip, port, err := SetupMySQLContainer()
+	c, svc, err := SetupMySQLContainer()
 	if err != nil {
 		return c, fmt.Errorf("Could not set up MySQL container: %v", err)
 	}
 
 	for try := 0; try <= tries; try++ {
 		time.Sleep(delay)
-		url := fmt.Sprintf("%s:%s@tcp(%s:%d)/mysql", MySQLUsername, MySQLPassword, ip, port)
+		url := fmt.Sprintf("%s:%s@tcp(%s)/mysql", MySQLUsername, MySQLPassword, svc)
 		if connector(url) {
 			return c, nil
 		}

--- a/nsq.go
+++ b/nsq.go
@@ -8,62 +8,42 @@ import (
 )
 
 // SetupNSQdContainer sets up a real NSQ instance for testing purposes
-// using a Docker container and executing `/nsqd`. It returns the container ID and its IP address,
+// using a Docker container and executing `/nsqd`. It returns the container ID and tcp,http services,
 // or makes the test fail on error.
-func SetupNSQdContainer() (c ContainerID, ip string, tcpPort int, httpPort int, err error) {
+func SetupNSQdContainer() (c ContainerID, svcs ServicePorts, err error) {
 	// --name nsqd -p 4150:4150 -p 4151:4151 nsqio/nsq /nsqd --broadcast-address=192.168.99.100 --lookupd-tcp-address=192.168.99.100:4160
-	tcpPort = RandomPort()
-	httpPort = RandomPort()
-	tcpForward := fmt.Sprintf("%d:%d", tcpPort, 4150)
-	if BindDockerToLocalhost != "" {
-		tcpForward = "127.0.0.1:" + tcpForward
-	}
-
-	httpForward := fmt.Sprintf("%d:%d", httpPort, 4151)
-	if BindDockerToLocalhost != "" {
-		httpForward = "127.0.0.1:" + httpForward
-	}
-
-	c, ip, err = SetupContainer(NSQImageName, tcpPort, 15*time.Second, func() (string, error) {
-		return run("--name", GenerateContainerID(), "-d", "-P", "-p", tcpForward, "-p", httpForward, NSQImageName, "/nsqd", fmt.Sprintf("--broadcast-address=%s", ip), fmt.Sprintf("--lookupd-tcp-address=%s:4160", ip))
+	ports := []int{4150, 4151}
+	c, svcs, err = SetupMultiportContainer(NSQImageName, ports, 15*time.Second, func() (string, error) {
+		return runService(ports, "--name", GenerateContainerID(), "-d", "-P", NSQImageName, "/nsqd")
 	})
 	return
 }
 
 // SetupNSQLookupdContainer sets up a real NSQ instance for testing purposes
-// using a Docker container and executing `/nsqlookupd`. It returns the container ID and its IP address,
+// using a Docker container and executing `/nsqlookupd`. It returns the container ID and tcp,http services,
 // or makes the test fail on error.
-func SetupNSQLookupdContainer() (c ContainerID, ip string, tcpPort int, httpPort int, err error) {
+func SetupNSQLookupdContainer() (c ContainerID, svcs ServicePorts, err error) {
 	// docker run --name lookupd -p 4160:4160 -p 4161:4161 nsqio/nsq /nsqlookupd
-	tcpPort = RandomPort()
-	httpPort = RandomPort()
-	tcpForward := fmt.Sprintf("%d:%d", tcpPort, 4160)
-	if BindDockerToLocalhost != "" {
-		tcpForward = "127.0.0.1:" + tcpForward
-	}
-
-	httpForward := fmt.Sprintf("%d:%d", httpPort, 4161)
-	if BindDockerToLocalhost != "" {
-		httpForward = "127.0.0.1:" + httpForward
-	}
-
-	c, ip, err = SetupContainer(NSQImageName, tcpPort, 15*time.Second, func() (string, error) {
-		return run("--name", GenerateContainerID(), "-d", "-P", "-p", tcpForward, "-p", httpForward, NSQImageName, "/nsqlookupd")
+	ports := []int{4160, 4161}
+	c, svcs, err = SetupMultiportContainer(NSQImageName, ports, 15*time.Second, func() (string, error) {
+		return runService(ports, "--name", GenerateContainerID(), "-d", "-P", NSQImageName, "/nsqlookupd")
 	})
 	return
 }
 
 // ConnectToNSQLookupd starts a NSQ image with `/nsqlookupd` running and passes the IP, HTTP port, and TCP port to the connector callback function.
 // The url will match the ip pattern (e.g. 123.123.123.123).
-func ConnectToNSQLookupd(tries int, delay time.Duration, connector func(ip string, httpPort int, tcpPort int) bool) (c ContainerID, err error) {
-	c, ip, tcpPort, httpPort, err := SetupNSQLookupdContainer()
+func ConnectToNSQLookupd(tries int, delay time.Duration, connector func(httpPort, tcpPort ServicePort) bool) (c ContainerID, err error) {
+	c, svcs, err := SetupNSQLookupdContainer()
 	if err != nil {
 		return c, fmt.Errorf("Could not set up NSQLookupd container: %v", err)
 	}
+	tcpPort := svcs[0]
+	httpPort := svcs[1]
 
 	for try := 0; try <= tries; try++ {
 		time.Sleep(delay)
-		if connector(ip, httpPort, tcpPort) {
+		if connector(httpPort, tcpPort) {
 			return c, nil
 		}
 		log.Printf("Try %d failed. Retrying.", try)
@@ -73,15 +53,17 @@ func ConnectToNSQLookupd(tries int, delay time.Duration, connector func(ip strin
 
 // ConnectToNSQd starts a NSQ image with `/nsqd` running and passes the IP, HTTP port, and TCP port to the connector callback function.
 // The url will match the ip pattern (e.g. 123.123.123.123).
-func ConnectToNSQd(tries int, delay time.Duration, connector func(ip string, httpPort int, tcpPort int) bool) (c ContainerID, err error) {
-	c, ip, tcpPort, httpPort, err := SetupNSQdContainer()
+func ConnectToNSQd(tries int, delay time.Duration, connector func(httpPort, tcpPort ServicePort) bool) (c ContainerID, err error) {
+	c, svcs, err := SetupNSQdContainer()
 	if err != nil {
 		return c, fmt.Errorf("Could not set up NSQd container: %v", err)
 	}
+	tcpPort := svcs[0]
+	httpPort := svcs[1]
 
 	for try := 0; try <= tries; try++ {
 		time.Sleep(delay)
-		if connector(ip, httpPort, tcpPort) {
+		if connector(httpPort, tcpPort) {
 			return c, nil
 		}
 		log.Printf("Try %d failed. Retrying.", try)

--- a/rabbitmq.go
+++ b/rabbitmq.go
@@ -8,16 +8,11 @@ import (
 )
 
 // SetupRabbitMQContainer sets up a real RabbitMQ instance for testing purposes,
-// using a Docker container. It returns the container ID and its IP address,
+// using a Docker container. It returns the container ID and its Service,
 // or makes the test fail on error.
-func SetupRabbitMQContainer() (c ContainerID, ip string, port int, err error) {
-	port = RandomPort()
-	forward := fmt.Sprintf("%d:%d", port, 5672)
-	if BindDockerToLocalhost != "" {
-		forward = "127.0.0.1:" + forward
-	}
-	c, ip, err = SetupContainer(RabbitMQImageName, port, 10*time.Second, func() (string, error) {
-		res, err := run("--name", GenerateContainerID(), "-d", "-P", "-p", forward, RabbitMQImageName)
+func SetupRabbitMQContainer() (c ContainerID, svc ServicePort, err error) {
+	c, svc, err = SetupContainer(RabbitMQImageName, 5672, 10*time.Second, func() (string, error) {
+		res, err := runService([]int{5672}, "--name", GenerateContainerID(), "-d", "-P", RabbitMQImageName)
 		return res, err
 	})
 	return
@@ -26,15 +21,14 @@ func SetupRabbitMQContainer() (c ContainerID, ip string, port int, err error) {
 // ConnectToRabbitMQ starts a RabbitMQ image and passes the amqp url to the connector callback.
 // The url will match the ip:port pattern (e.g. 123.123.123.123:4241)
 func ConnectToRabbitMQ(tries int, delay time.Duration, connector func(url string) bool) (c ContainerID, err error) {
-	c, ip, port, err := SetupRabbitMQContainer()
+	c, svc, err := SetupRabbitMQContainer()
 	if err != nil {
 		return c, fmt.Errorf("Could not set up RabbitMQ container: %v", err)
 	}
 
 	for try := 0; try <= tries; try++ {
 		time.Sleep(delay)
-		url := fmt.Sprintf("%s:%d", ip, port)
-		if connector(url) {
+		if connector(svc.String()) {
 			return c, nil
 		}
 		log.Printf("Try %d failed. Retrying.", try)

--- a/redis.go
+++ b/redis.go
@@ -8,16 +8,11 @@ import (
 )
 
 // SetupRedisContainer sets up a real Redis instance for testing purposes
-// using a Docker container. It returns the container ID and its IP address,
+// using a Docker container. It returns the container ID and its Service,
 // or makes the test fail on error.
-func SetupRedisContainer() (c ContainerID, ip string, port int, err error) {
-	port = RandomPort()
-	forward := fmt.Sprintf("%d:%d", port, 6379)
-	if BindDockerToLocalhost != "" {
-		forward = "127.0.0.1:" + forward
-	}
-	c, ip, err = SetupContainer(RedisImageName, port, 15*time.Second, func() (string, error) {
-		return run("--name", GenerateContainerID(), "-d", "-P", "-p", forward, RedisImageName)
+func SetupRedisContainer() (c ContainerID, svc ServicePort, err error) {
+	c, svc, err = SetupContainer(RedisImageName, 6379, 15*time.Second, func() (string, error) {
+		return runService([]int{6379}, "--name", GenerateContainerID(), "-d", "-P", RedisImageName)
 	})
 	return
 }
@@ -25,15 +20,14 @@ func SetupRedisContainer() (c ContainerID, ip string, port int, err error) {
 // ConnectToRedis starts a Redis image and passes the database url to the connector callback function.
 // The url will match the ip:port pattern (e.g. 123.123.123.123:6379)
 func ConnectToRedis(tries int, delay time.Duration, connector func(url string) bool) (c ContainerID, err error) {
-	c, ip, port, err := SetupRedisContainer()
+	c, svc, err := SetupRedisContainer()
 	if err != nil {
 		return c, fmt.Errorf("Could not set up Redis container: %v", err)
 	}
 
 	for try := 0; try <= tries; try++ {
 		time.Sleep(delay)
-		url := fmt.Sprintf("%s:%d", ip, port)
-		if connector(url) {
+		if connector(svc.String()) {
 			return c, nil
 		}
 		log.Printf("Try %d failed. Retrying.", try)

--- a/service.go
+++ b/service.go
@@ -1,0 +1,51 @@
+package dockertest
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"camlistore.org/pkg/netutil"
+)
+
+// A structure representing
+type ServicePort struct {
+	Host string `json:"HostIP"`
+	Port string `json:"HostPort"`
+}
+
+func (sp ServicePort) String() string {
+	return net.JoinHostPort(sp.Host, sp.Port)
+}
+
+type ServicePorts []ServicePort
+
+func (svcs ServicePorts) First() ServicePort {
+	if len(svcs) == 0 {
+		panic("ServicePorts.First(): empty list")
+	}
+	return svcs[0]
+}
+
+func (svcs ServicePorts) Wait(timeout time.Duration) error {
+	for _, svc := range svcs {
+		if err := netutil.AwaitReachable(svc.String(), timeout); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type ServicePortMap map[int]ServicePort
+
+func (spm ServicePortMap) Ordered(order []int) (ServicePorts, error) {
+	res := make(ServicePorts, len(order))
+	for i, p := range order {
+		var ok bool
+		res[i], ok = spm[p]
+		if !ok {
+			return ServicePorts{}, fmt.Errorf("Port %d not found", p)
+		}
+	}
+	return res, nil
+}

--- a/service_test.go
+++ b/service_test.go
@@ -1,0 +1,35 @@
+package dockertest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServicePorts(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.Panics(func() { ServicePorts{}.First() })
+	assert.Equal(ServicePorts{
+		ServicePort{Host: "1"},
+		ServicePort{Host: "2"},
+	}.First(), ServicePort{Host: "1"})
+
+	assert.NoError(ServicePorts{}.Wait(time.Millisecond * 500))
+	assert.Error(ServicePorts{ServicePort{Host: "does-not-exist.tld", Port: "65535"}}.Wait(time.Millisecond * 500))
+}
+
+func TestServicePortMap(t *testing.T) {
+	assert := assert.New(t)
+
+	{
+		servicePorts, err := ServicePortMap{14: ServicePort{Port: "8"}, 8: ServicePort{Port: "8"}}.Ordered([]int{14})
+		assert.Nil(err)
+		assert.Equal(servicePorts, ServicePorts{ServicePort{Port: "8"}})
+	}
+	{
+		_, err := ServicePortMap{}.Ordered([]int{14})
+		assert.Error(err)
+	}
+}


### PR DESCRIPTION
The core idea is to introduce a "ServicePort" type, read from
"docker inspect", describing how to access an exposed service
from the running container.

It solves a few problems;
 - RandomPort is not used, docker is allowed to allocate it's
   own ports, guaranteed to be unused.
 - Port-allocation is moved to docker, greatly simplifying
   the code in the service-specific functions.
 - Makes dockertest work running on the docker-host. I.E.
   with automated docker-in-docker-tests.
 - With some more work, some cases would not require
   forwarding at all.

The API is changed such that (ip, port) results and arguments
are replaced by the ServicePort(s)-structure.

This PR is a pretty open suggestion, intended for discussion. Can the API be broken? (dockertest.v3?) If so, maybe some more aspects of internal and external API:s should be addressed. For example, the way SetupContainer is actually used, it could be greatly simplifed without a callback and using static timeouts. `SetupServices(image string, ports []int, dockerArgs, appArgs []string)`

If keeping the API is a strict priority, the patch can be rewritten for that.