### PR TITLE
core: add cassandra

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Dockertest ships with support for these backends:
 * Mockserver
 * ActiveMQ
 * ZooKeeper
+* Cassandra
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->

--- a/cassandra.go
+++ b/cassandra.go
@@ -1,0 +1,47 @@
+package dockertest
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"time"
+)
+
+// SetupCassandraContainer sets up a real Cassandra node for testing purposes,
+// using a Docker container. It returns the container ID and its IP address,
+// or makes the test fail on error.
+func SetupCassandraContainer(versionTag string) (c ContainerID, ip string, port int, err error) {
+	port = RandomPort()
+
+	// Forward for the CQL port.
+	forward := fmt.Sprintf("%d:%d", port, 9042)
+	if BindDockerToLocalhost != "" {
+		forward = "127.0.0.1:" + forward
+	}
+
+	imageName := fmt.Sprintf("%s:%s", CassandraImageName, versionTag)
+
+	c, ip, err = SetupContainer(imageName, port, 10*time.Second, func() (string, error) {
+		return run("--name", GenerateContainerID(), "-d", "-P", "-p", forward, imageName)
+	})
+	return
+}
+
+// ConnectToCassandra starts a Cassandra image and passes the nodes connection string to the connector callback function.
+// The connection string will match the ip:port pattern, where port is the mapped CQL port.
+func ConnectToCassandra(versionTag string, tries int, delay time.Duration, connector func(url string) bool) (c ContainerID, err error) {
+	c, ip, port, err := SetupCassandraContainer(versionTag)
+	if err != nil {
+		return c, fmt.Errorf("Could not setup Cassandra container: %v", err)
+	}
+
+	for try := 0; try <= tries; try++ {
+		time.Sleep(delay)
+		url := fmt.Sprintf("%s:%d", ip, port)
+		if connector(url) {
+			return c, nil
+		}
+		log.Printf("Try %d failed. Retrying.", try)
+	}
+	return c, errors.New("Could not setup Cassandra container.")
+}

--- a/vars.go
+++ b/vars.go
@@ -60,6 +60,9 @@ var (
 
 	// ZooKeeperImageName is the ZooKeeper image name on dockerhub.
 	ZooKeeperImageName = env.Getenv("DOCKERTEST_ZOOKEEPER_IMAGE_NAME", "jplock/zookeeper")
+
+	// CassandraImageName is the Cassandra image name on dockerhub.
+	CassandraImageName = env.Getenv("DOCKERTEST_CASSANDRA_IMAGE_NAME", "cassandra")
 )
 
 // Username and password configuration

--- a/zookeeper.go
+++ b/zookeeper.go
@@ -23,7 +23,7 @@ func SetupZooKeeperContainer() (c ContainerID, ip string, port int, err error) {
 	return
 }
 
-// ConnectToZooKeeper starts a MySQL image and passes the nodes connection string to the connector callback function.
+// ConnectToZooKeeper starts a ZooKeeper image and passes the nodes connection string to the connector callback function.
 // The connection string will match the ip:port pattern.
 func ConnectToZooKeeper(tries int, delay time.Duration, connector func(url string) bool) (c ContainerID, err error) {
 	c, ip, port, err := SetupZooKeeperContainer()


### PR DESCRIPTION
Summary
---
* Adds support for Cassandra (addresses #54)
* Fixes comment for `ConnectToZooKeeper`

Cassandra has a lot of different versions, some of which aren't compatible with others (i.e. the 2.x and 3.x series). Additionally, there may be subtle changes within version series that may matter to some people. I haven't done any deep digging / formal research, but it seems that the distribution of Cassandra versions being used is pretty big.

To address this, I added a `versionTag` to the `ConnectToCassandra` and `SetupCassandraContainer`, so callers have the ability so specify the version they want.

Another issue is the fact Cassandra offers two primary ports: CQL and Thrift. However, thrift is deprecated, and most of the go Cassandra libraries I found (first few pages of a google search) all seem to be using CQL. Therefore, to keep things simple, I only exposed the CQL port.

If there are better ways / suggestions to improving this, I'm happy to make changes.