### PR TITLE
core: add optional parameters to cassandra

### DIFF
--- a/cassandra.go
+++ b/cassandra.go
@@ -10,7 +10,7 @@ import (
 // SetupCassandraContainer sets up a real Cassandra node for testing purposes,
 // using a Docker container. It returns the container ID and its IP address,
 // or makes the test fail on error.
-func SetupCassandraContainer(versionTag string) (c ContainerID, ip string, port int, err error) {
+func SetupCassandraContainer(versionTag string, optionalParams ...string) (c ContainerID, ip string, port int, err error) {
 	port = RandomPort()
 
 	// Forward for the CQL port.
@@ -22,15 +22,15 @@ func SetupCassandraContainer(versionTag string) (c ContainerID, ip string, port 
 	imageName := fmt.Sprintf("%s:%s", CassandraImageName, versionTag)
 
 	c, ip, err = SetupContainer(imageName, port, 10*time.Second, func() (string, error) {
-		return run("--name", GenerateContainerID(), "-d", "-P", "-p", forward, imageName)
+		return run(append(optionalParams, "--name", GenerateContainerID(), "-d", "-p", forward, imageName)...)
 	})
 	return
 }
 
 // ConnectToCassandra starts a Cassandra image and passes the nodes connection string to the connector callback function.
 // The connection string will match the ip:port pattern, where port is the mapped CQL port.
-func ConnectToCassandra(versionTag string, tries int, delay time.Duration, connector func(url string) bool) (c ContainerID, err error) {
-	c, ip, port, err := SetupCassandraContainer(versionTag)
+func ConnectToCassandra(versionTag string, tries int, delay time.Duration, connector func(url string) bool, optionalParams ...string) (c ContainerID, err error) {
+	c, ip, port, err := SetupCassandraContainer(versionTag, optionalParams...)
 	if err != nil {
 		return c, fmt.Errorf("Could not setup Cassandra container: %v", err)
 	}


### PR DESCRIPTION
Summary
---
* Ability to provide additional options to Cassandra, as suggested by @jerome-laforge