### PR TITLE
core: add start()/stop()

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Dockertest ships with support for these backends:
 
 When developing applications, it is often necessary to use services that talk to a database system.
 Unit Testing these services can be cumbersome because mocking database/DBAL is strenuous. Making slight changes to the
-schema implies rewriting at least some, if not all of the mocks. The same goes for API changes in the DBAL.  
+schema implies rewriting at least some, if not all of the mocks. The same goes for API changes in the DBAL.
 To avoid this, it is smarter to test these specific services against a real database that is destroyed after testing.
 Docker is the perfect system for running unit tests as you can spin up containers in a few seconds and kill them when
 the test completes. The Dockertest library provides easy to use commands for spinning up Docker containers and using
@@ -72,7 +72,7 @@ where `X` is your desired version. For example:
 go get gopkg.in/ory-am/dockertest.v2
 ```
 
-**Note:**  
+**Note:**
 When using the Docker Toolbox (Windows / OSX), make sure that the VM is started by running `docker-machine start default`.
 
 ### Start a container
@@ -91,32 +91,64 @@ func main() {
 	c, err := dockertest.ConnectToMongoDB(15, time.Millisecond*500, func(url string) bool {
 	    // This callback function checks if the image's process is responsive.
 	    // Sometimes, docker images are booted but the process (in this case MongoDB) is still doing maintenance
-	    // before being fully responsive which might cause issues like "TCP Connection reset by peer".	
+	    // before being fully responsive which might cause issues like "TCP Connection reset by peer".
 		var err error
 		db, err = mgo.Dial(url)
 		if err != nil {
 			return false
 		}
-		
+
 		// Sometimes, dialing the database is not enough because the port is already open but the process is not responsive.
 		// Most database conenctors implement a ping function which can be used to test if the process is responsive.
 		// Alternatively, you could execute a query to see if an error occurs or not.
 		return db.Ping() == nil
 	})
-	
+
 	if err != nil {
 	    log.Fatalf("Could not connect to database: %s", err)
 	}
-	
+
 	// Close db connection and kill the container when we leave this function body.
     defer db.Close()
 	defer c.KillRemove()
-	
+
 	// The image is now responsive.
 }
 ```
 
 You can start PostgreSQL and MySQL in a similar fashion.
+
+There are some cases where it's useful to test how your application/code handles
+remote resources failing / shutting down. For example, what if your database
+goes offline? Does your application handle it gracefully?
+
+This can be tested by stopping and starting an existing container:
+
+```go
+	var hosts []string
+	c, err := ConnectToZooKeeper(15, time.Millisecond*500, func(url string) bool {
+		conn, _, err := zk.Connect([]string{url}, time.Second)
+		if err != nil {
+			return false
+		}
+		defer conn.Close()
+		hosts = []string{url}
+
+		return true
+	})
+	defer c.KillRemove()
+
+	conn, _, _ := zk.Connect(hosts, time.Second)
+	conn.Create("/test", []byte("hello"), 0, zk.WorldACL(zk.PermAll))
+
+	c.Stop()
+
+	_, _, err = zk.Get("/test") // err == zk.ErrNoServer
+
+	c.Start()
+
+	data, _, _ = zk.Get("/test") // data == []byte("hello")
+```
 
 It is also possible to start a custom container (in this example, a RabbitMQ container):
 
@@ -171,18 +203,18 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatalf("Could not connect to database: %s", err)
 	}
-	
+
 	// Execute tasks like setting up schemata.
-	
+
 	// Run tests
 	result := m.Run()
-	
+
 	// Close database connection.
 	db.Close()
-	
+
 	// Clean up image.
 	c.KillRemove()
-	
+
 	// Exit tests.
 	os.Exit(result)
 }

--- a/container.go
+++ b/container.go
@@ -2,10 +2,10 @@ package dockertest
 
 import (
 	"fmt"
+	"net"
 	"os/exec"
 	"strings"
 	"time"
-	"net"
 )
 
 // AwaitReachable tries to make a TCP connection to addr regularly.
@@ -34,6 +34,16 @@ func (c ContainerID) IP() (string, error) {
 // Kill runs "docker kill" on the container.
 func (c ContainerID) Kill() error {
 	return KillContainer(string(c))
+}
+
+// Start runs "docker start" on the container.
+func (c ContainerID) Start() error {
+	return StartContainer(string(c))
+}
+
+// Stop runs "docker stop" on the container.
+func (c ContainerID) Stop() error {
+	return StopContainer(string(c))
 }
 
 // Remove runs "docker rm" on the container

--- a/docker.go
+++ b/docker.go
@@ -177,6 +177,22 @@ func KillContainer(container string) error {
 	return nil
 }
 
+// StartContainer runs 'docker start' on a container.
+func StartContainer(container string) error {
+	if container != "" {
+		return runDockerCommand("docker", "start", container).Run()
+	}
+	return nil
+}
+
+// StopContainer runs 'docker stop' on a container.
+func StopContainer(container string) error {
+	if container != "" {
+		return runDockerCommand("docker", "stop", container).Run()
+	}
+	return nil
+}
+
 // Pull retrieves the docker image with 'docker pull'.
 func Pull(image string) error {
 	out, err := runDockerCommand("docker", "pull", image).CombinedOutput()

--- a/docker_integration_test.go
+++ b/docker_integration_test.go
@@ -337,6 +337,46 @@ func TestConnectToCassandra(t *testing.T) {
 	defer c.KillRemove()
 }
 
+func TestStartStopContainer(t *testing.T) {
+	var hosts []string
+	c, err := ConnectToZooKeeper(15, time.Millisecond*500, func(url string) bool {
+		conn, _, err := zk.Connect([]string{url}, time.Second)
+		if err != nil {
+			return false
+		}
+		defer conn.Close()
+		hosts = []string{url}
+
+		return true
+	})
+	assert.NoError(t, err)
+	defer c.KillRemove()
+
+	conn, _, err := zk.Connect(hosts, time.Second)
+	assert.NoError(t, err)
+
+	testPath := "/test"
+	testData := []byte("hello")
+
+	path, err := conn.Create(testPath, testData, 0, zk.WorldACL(zk.PermAll))
+	assert.NoError(t, err)
+	assert.Equal(t, testPath, path)
+
+	data, _, err := conn.Get(testPath)
+	assert.NoError(t, err)
+	assert.Equal(t, testData, data)
+
+	// Let's stop the container.
+	assert.NoError(t, c.Stop())
+
+	_, _, err = conn.Get(testPath)
+	assert.EqualError(t, err, zk.ErrNoServer.Error())
+
+	assert.NoError(t, c.Start())
+	data, _, err = conn.Get(testPath)
+	assert.Equal(t, testData, data)
+}
+
 func TestHaveImage(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
Summary
---
* Support the ability to start and stop a container.
* Useful for testing certain failure modes, such as what happens if you lose connection / one of your databases/backends goes down.
* Not sure how this fits into V3. I'd be happy to open a PR into V3 if needed, I'd just have to dig around to see how it works first.

Used ZooKeeper to test Start()/Stop(), since it's already in the integration test, and was an easy way to verify that the container was stopped / restarted.